### PR TITLE
Align import to history 4.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Assuming you know how to use `history`, if not, check its [document](https://git
   Initalize `mobx-history` with `history` object:
 
 ```js
-import createMemoryHistoryfrom 'history/createMemoryHistory'
+import { createMemoryHistory } from 'history'
 let history = new History(createMemoryHistory())
 
 // or just change 'history' to 'mobx-history'
-import createMemoryHistory from 'mobx-history/createMemoryHistory'
+import { createMemoryHistory } from 'mobx-history'
 var history = createMemoryHistory();
 ```
 

--- a/src/createBrowserHistory.js
+++ b/src/createBrowserHistory.js
@@ -1,4 +1,4 @@
-import createBrowserHistory from "history/createBrowserHistory";
+import { createBrowserHistory } from "history";
 import History from "./History";
 
 export default (props) => new History(createBrowserHistory(props));

--- a/src/createHashHistory.js
+++ b/src/createHashHistory.js
@@ -1,4 +1,4 @@
-import createHashHistory from "history/createHashHistory";
+import { createHashHistory } from "history";
 import History from "./History";
 
 export default (props) => new History(createHashHistory(props));

--- a/src/createMemoryHistory.js
+++ b/src/createMemoryHistory.js
@@ -1,4 +1,4 @@
-import createMemoryHistory from "history/createMemoryHistory";
+import { createMemoryHistory } from "history";
 import History from "./History";
 
 export default (props) => new History(createMemoryHistory(props));


### PR DESCRIPTION
`history` v4.9.0 deprecated the `require("history/createBrowserHistory")` importing. It now shows a deprecation warning when doing so.

It instead recommends `import { createBrowserHistory } from 'history'`;

See https://github.com/ReactTraining/history/releases/tag/v4.9.0.